### PR TITLE
Add backward compatibility for CloudEvents with old priority

### DIFF
--- a/tests/test_cloudevent/test_datamodel/test_ucloudevent.py
+++ b/tests/test_cloudevent/test_datamodel/test_ucloudevent.py
@@ -276,3 +276,20 @@ class TestUCloudEvent(unittest.TestCase):
         self.assertEquals(UCloudEvent.get_id(cloud_event),UCloudEvent.get_id(cloud_event1))
         self.assertEquals(UCloudEvent.get_type(cloud_event),UCloudEvent.get_type(cloud_event1))
         self.assertEquals(UCloudEvent.get_request_id(cloud_event),UCloudEvent.get_request_id(cloud_event1))
+
+    def test_to_from_message_from_UCP_cloudevent(self):
+        # additional attributes
+        u_cloud_event_attributes = UCloudEventAttributesBuilder().with_ttl(3).with_token("someOAuthToken").build()
+
+        cloud_event = CloudEventFactory.request(build_uri_for_test(), "//bo.cloud/petapp/1/rpc.response",
+                                                CloudEventFactory.generate_cloud_event_id(),
+                                                build_proto_payload_for_test(),
+                                                u_cloud_event_attributes)
+        cloud_event.__setitem__("priority", "CS4")
+
+        result = UCloudEvent.toMessage(cloud_event)
+        self.assertIsNotNone(result)
+        self.assertEquals(UPriority.UPRIORITY_CS4,result.attributes.priority)
+        cloud_event1 = UCloudEvent.fromMessage(result)
+        self.assertEquals(UCloudEvent.get_priority(cloud_event1),UPriority.Name(result.attributes.priority))
+

--- a/uprotocol/cloudevent/factory/ucloudevent.py
+++ b/uprotocol/cloudevent/factory/ucloudevent.py
@@ -456,6 +456,10 @@ class UCloudEvent:
         if UCloudEvent.has_communication_status_problem(event):
             attributes.commstatus = UCloudEvent.get_communication_status(event)
         priority = UCloudEvent.get_priority(event)
+
+        if priority and 'UPRIORITY_' not in priority:
+            priority = 'UPRIORITY_' + priority
+
         if priority is not None:
             attributes.priority = priority
 


### PR DESCRIPTION
This commit addresses Issue #9 